### PR TITLE
feat: Sass 및 스타일 관련 파일 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import ReactQueryProvider from '@/lib/react-query/ReactQueryProvider';
 import MSWComponent from '@/components/MSWComponent';
-import './globals.css';
+import '@/styles/global.scss';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',

--- a/components/FAQAccordion/FAQAccordion.module.scss
+++ b/components/FAQAccordion/FAQAccordion.module.scss
@@ -1,3 +1,5 @@
+@import '@/styles/breakpoints';
+
 .item {
   display: flex;
   flex-direction: column;
@@ -30,7 +32,7 @@
   display: none;
 }
 
-@media (max-width: 768px) {
+@include mobile-and-tablet {
   .arrowRight {
     display: block;
     transform: rotate(-90deg) scale(0.67);

--- a/components/FAQAccordion/index.tsx
+++ b/components/FAQAccordion/index.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Faq } from '@/types';
 import ArrowIcon from '@/assets/icons/arrow_icon.svg';
-import styles from './FAQAccordion.module.css';
+import styles from './FAQAccordion.module.scss';
 
 type FAQAccordionProps = Faq;
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "sass": "^1.86.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.69.0(react@19.0.0)
       next:
         specifier: 15.2.3
-        version: 15.2.3(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.3(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.86.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -26,6 +26,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@19.0.0)
+      sass:
+        specifier: ^1.86.0
+        version: 1.86.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -59,10 +62,10 @@ importers:
         version: 19.0.4(@types/react@19.0.12)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0))
+        version: 4.3.4(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0))
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(yaml@2.7.0))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(sass@1.86.0)(yaml@2.7.0))
       eslint:
         specifier: ^9
         version: 9.23.0
@@ -107,13 +110,13 @@ importers:
         version: 5.8.2
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.37.0)(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0))
+        version: 4.3.0(rollup@4.37.0)(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0))
+        version: 5.1.4(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0))
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(yaml@2.7.0)
+        version: 3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(sass@1.86.0)(yaml@2.7.0)
 
 packages:
 
@@ -1199,6 +1202,88 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@parcel/watcher-android-arm64@2.5.1':
+    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.1':
+    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.1':
+    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.5.1':
+    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.1':
+    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.1':
+    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.1':
+    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
+    engines: {node: '>= 10.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1857,6 +1942,10 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -2025,6 +2114,11 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
@@ -2504,6 +2598,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immutable@5.0.3:
+    resolution: {integrity: sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2900,6 +2997,9 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -3105,6 +3205,10 @@ packages:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3199,6 +3303,11 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass@1.86.0:
+    resolution: {integrity: sha512-zV8vGUld/+mP4KbMLJMX7TyGCuUp7hnkOScgCMsWuHtns8CWBoz+vmEhoGMXsaJrbUP8gj+F1dLvVe79sK8UdA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -4899,6 +5008,67 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@parcel/watcher-android-arm64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.1':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.1':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.1':
+    optional: true
+
+  '@parcel/watcher@2.5.1':
+    dependencies:
+      detect-libc: 1.0.3
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      node-addon-api: 7.1.1
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.1
+      '@parcel/watcher-darwin-arm64': 2.5.1
+      '@parcel/watcher-darwin-x64': 2.5.1
+      '@parcel/watcher-freebsd-x64': 2.5.1
+      '@parcel/watcher-linux-arm-glibc': 2.5.1
+      '@parcel/watcher-linux-arm-musl': 2.5.1
+      '@parcel/watcher-linux-arm64-glibc': 2.5.1
+      '@parcel/watcher-linux-arm64-musl': 2.5.1
+      '@parcel/watcher-linux-x64-glibc': 2.5.1
+      '@parcel/watcher-linux-x64-musl': 2.5.1
+      '@parcel/watcher-win32-arm64': 2.5.1
+      '@parcel/watcher-win32-ia32': 2.5.1
+      '@parcel/watcher-win32-x64': 2.5.1
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -5287,18 +5457,18 @@ snapshots:
   '@unrs/rspack-resolver-binding-win32-x64-msvc@1.2.2':
     optional: true
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.2(@types/node@20.17.25)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(sass@1.86.0)(yaml@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -5312,7 +5482,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(yaml@2.7.0)
+      vitest: 3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(sass@1.86.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5323,14 +5493,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.3(@types/node@20.17.25)(typescript@5.8.2)
-      vite: 6.2.2(@types/node@20.17.25)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -5581,6 +5751,10 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -5742,6 +5916,9 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@1.0.3:
+    optional: true
 
   detect-libc@2.0.3:
     optional: true
@@ -6377,6 +6554,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immutable@5.0.3: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6780,7 +6959,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.2.3(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.2.3(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.86.0):
     dependencies:
       '@next/env': 15.2.3
       '@swc/counter': 0.1.3
@@ -6800,6 +6979,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.2.3
       '@next/swc-win32-arm64-msvc': 15.2.3
       '@next/swc-win32-x64-msvc': 15.2.3
+      sass: 1.86.0
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6809,6 +6989,9 @@ snapshots:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
+
+  node-addon-api@7.1.1:
+    optional: true
 
   node-releases@2.0.19: {}
 
@@ -7004,6 +7187,8 @@ snapshots:
 
   react@19.0.0: {}
 
+  readdirp@4.1.2: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -7146,6 +7331,14 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sass@1.86.0:
+    dependencies:
+      chokidar: 4.0.3
+      immutable: 5.0.3
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.5.1
 
   saxes@6.0.0:
     dependencies:
@@ -7557,13 +7750,13 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite-node@3.0.9(@types/node@20.17.25)(yaml@2.7.0):
+  vite-node@3.0.9(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.2(@types/node@20.17.25)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7578,29 +7771,29 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-svgr@4.3.0(rollup@4.37.0)(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0)):
+  vite-plugin-svgr@4.3.0(rollup@4.37.0)(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
       '@svgr/core': 8.1.0(typescript@5.8.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))
-      vite: 6.2.2(@types/node@20.17.25)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.2.2(@types/node@20.17.25)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0):
+  vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -7608,12 +7801,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.25
       fsevents: 2.3.3
+      sass: 1.86.0
       yaml: 2.7.0
 
-  vitest@3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(yaml@2.7.0):
+  vitest@3.0.9(@types/node@20.17.25)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(sass@1.86.0)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.2(@types/node@20.17.25)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -7629,8 +7823,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.2(@types/node@20.17.25)(yaml@2.7.0)
-      vite-node: 3.0.9(@types/node@20.17.25)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
+      vite-node: 3.0.9(@types/node@20.17.25)(sass@1.86.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.25

--- a/styles/_breakpoints.scss
+++ b/styles/_breakpoints.scss
@@ -1,0 +1,76 @@
+// 브레이크포인트 값 정의
+$breakpoints: (
+  mobile: 743px,   // 모바일 최대 너비
+  tablet: 1023px,  // 태블릿 최대 너비
+  desktop: 1439px  // 소형 데스크탑 최대 너비
+);
+
+/**
+ * 모바일 장치에만 적용되는 스타일
+ * 최대 너비: 743px
+ */
+@mixin mobile {
+  @media (max-width: map-get($breakpoints, mobile)) {
+    @content;
+  }
+}
+
+/**
+ * 태블릿 장치에만 적용되는 스타일
+ * 너비 범위: 744px ~ 1023px
+ */
+@mixin tablet {
+  @media (min-width: #{map-get($breakpoints, mobile) + 1px}) and (max-width: #{map-get($breakpoints, tablet)}) {
+    @content;
+  }
+}
+
+/**
+ * 모바일 및 태블릿에 적용되는 스타일 (태블릿 이하)
+ * 최대 너비: 1023px
+ */
+@mixin mobile-and-tablet {
+  @media (max-width: map-get($breakpoints, tablet)) {
+    @content;
+  }
+}
+
+/**
+ * 태블릿 및 데스크탑에 적용되는 스타일 (태블릿 이상)
+ * 최소 너비: 744px
+ */
+@mixin tablet-and-desktop {
+  @media (min-width: #{map-get($breakpoints, mobile) + 1px}) {
+    @content;
+  }
+}
+
+/**
+ * 소형 데스크탑에만 적용되는 스타일
+ * 너비 범위: 1024px ~ 1439px
+ */
+@mixin desktop-sm {
+  @media (min-width: #{map-get($breakpoints, tablet) + 1px}) and (max-width: #{map-get($breakpoints, desktop)}) {
+    @content;
+  }
+}
+
+/**
+ * 대형 데스크탑에만 적용되는 스타일
+ * 최소 너비: 1440px
+ */
+@mixin desktop-lg {
+  @media (min-width: #{map-get($breakpoints, desktop) + 1px}) {
+    @content;
+  }
+}
+
+/**
+ * 모든 데스크탑에 적용되는 스타일 (소형 및 대형)
+ * 최소 너비: 1024px
+ */
+@mixin desktop {
+  @media (min-width: #{map-get($breakpoints, tablet) + 1px}) {
+    @content;
+  }
+}

--- a/styles/_colors.scss
+++ b/styles/_colors.scss
@@ -1,0 +1,14 @@
+$mint-900: var(--mint-900);
+$mint-700: var(--mint-700);
+$midnight-900: var(--midnight-900);
+$midnight-100: var(--midnight-100);
+$red: var(--red);
+$blue: var(--blue);
+$gray-700: var(--gray-700);
+$gray-500: var(--gray-500);
+$gray-400: var(--gray-400);
+$gray-300: var(--gray-300);
+$gray-200: var(--gray-200);
+$gray-100: var(--gray-100);
+$gray-50: var(--gray-50);
+$gray-10: var(--gray-10);

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -1,0 +1,69 @@
+$px-md: var(--px-md);
+$px-lg: var(--px-lg);
+$px-xlg: var(--px-xlg);
+$space-xsm: var(--space-xsm);
+$space-xsm2: var(--space-xsm2);
+$space-sm: var(--space-sm);
+$space-sm2: var(--space-sm2);
+$space-md: var(--space-md);
+$space-md2: var(--space-md2);
+$space-md3: var(--space-md3);
+$space-box: var(--space-box);
+$space-box2: var(--space-box2);
+
+$heading-2: var(--heading-2);
+$heading-4: var(--heading-4);
+$heading-info: var(--heading-info);
+$heading-box: var(--heading-box);
+$h1-fsize: var(--h1-fsize);
+$h1-fsize-sm: var(--h1-fsize-sm);
+$tab-fsize: var(--tab-fsize);
+$list-more-size: var(--list-more-size);
+$gallery-list-title-size: var(--gallery-list-title-size);
+$board-heading-fsize: var(--board-heading-fsize);
+$faq-list-a-size: var(--faq-list-a-size);
+
+$heading-2-margin: var(--heading-2-margin);
+$heading-4-margin: var(--heading-4-margin);
+$gallery-list-title-space: var(--gallery-list-title-space);
+$gallery-list-space: var(--gallery-list-space);
+
+$input-md: var(--input-md);
+$input-md-fsize: var(--input-md-fsize);
+$textarea-md: var(--textarea-md);
+$btn-md: var(--btn-md);
+$btn-xlg: var(--btn-xlg);
+$btn-xlg2: var(--btn-xlg2);
+$btn-xxlg: var(--btn-xxlg);
+$btn-xxlg-size: var(--btn-xxlg-size);
+
+$ic-sm: var(--ic-sm);
+$ic-md: var(--ic-md);
+$ic-lg: var(--ic-lg);
+$ic-xlg: var(--ic-xlg);
+$ic-xlg2: var(--ic-xlg2);
+$ic-xxlg: var(--ic-xxlg);
+
+$max-width: var(--max-width);
+$header-height: var(--header-height);
+$footer-height: var(--footer-height);
+$side-padding: var(--side-padding);
+$bottom-padding: var(--bottom-padding);
+$h1-height: var(--h1-height);
+$search-bar-width: var(--search-bar-width);
+
+$line-height-sm: var(--line-height-sm);
+$line-height-md: var(--line-height-md);
+$line-height-lg: var(--line-height-lg);
+$cubic-bezier-primary: var(--cubic-bezier-primary);
+$gallery-list-length: var(--gallery-list-length);
+
+$board-head-padding: var(--board-head-padding);
+$board-body-padding-v: var(--board-body-padding-v);
+$board-body-padding-h: var(--board-body-padding-h);
+$board-media-max-width: var(--board-media-max-width);
+$board-footer-col-indent: var(--board-footer-col-indent);
+
+$faq-list-a-padding-v: var(--faq-list-a-padding-v);
+$faq-list-a-padding-h: var(--faq-list-a-padding-h);
+$faq-list-q-padding: var(--faq-list-q-padding);

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,0 +1,296 @@
+@import 'breakpoints';
+
+:root {
+  --mint-900: #70d7bf;
+  --mint-700: #8ddfcc;
+  --midnight-900: #05141f;
+  --midnight-100: #cdd0d2;
+  --red: #ff0900;
+  --blue: #4296e4;
+  --gray-700: #37434c;
+  --gray-500: #697278;
+  --gray-400: #82898f;
+  --gray-300: #b4b9bc;
+  --gray-200: #cdd0d2;
+  --gray-100: #e6e8e9;
+  --gray-50: #f6f6f9;
+  --gray-10: #f8f8f8;
+
+  --max-width: 1660px;
+  --line-height-sm: 1.4;
+  --line-height-md: 1.6;
+  --line-height-lg: 1.8;
+  --cubic-bezier-primary: cubic-bezier(1, 0, 0.2, 1);
+
+  font-size: 14px;
+  --px-md: 16px;
+  --px-lg: 24px;
+  --px-xlg: 32px;
+  --input-md: 40px;
+  --input-md-fsize: 16px;
+  --textarea-md: 140px;
+  --space-xsm: 8px;
+  --space-xsm2: 8px;
+  --space-sm: 12px;
+  --space-sm2: 12px;
+  --space-md: 16px;
+  --space-md2: 20px;
+  --space-md3: 20px;
+  --space-box: 48px;
+  --space-box2: 120px;
+  --heading-2: 20px;
+  --heading-2-margin: 48px 0 16px;
+  --heading-4: 16px;
+  --heading-4-margin: 20px 0 4px;
+  --heading-info: 16px;
+  --heading-box: 18px;
+  --btn-md: 36px;
+  --btn-xlg: 48px;
+  --btn-xlg2: 40px;
+  --btn-xxlg: 72px;
+  --btn-xxlg-size: 16px;
+  --ic-sm: 20px;
+  --ic-md: 24px;
+  --ic-lg: 32px;
+  --ic-xlg: 40px;
+  --ic-xlg2: 32px;
+  --ic-xxlg: 64px;
+  --header-height: 56px;
+  --footer-height: 284px;
+  --side-padding: 24px;
+  --bottom-padding: 80px;
+  --h1-height: 124px;
+  --h1-fsize: 24px;
+  --h1-fsize-sm: 14px;
+  --tab-fsize: var(--font-size);
+  --search-bar-width: 100%;
+  --gallery-list-length: 1;
+  --gallery-list-space: 0;
+  --gallery-list-title-space: 12px;
+  --gallery-list-title-size: 16px;
+  --list-more-size: 14px;
+  --board-head-padding: 16px 0;
+  --board-body-padding-v: var(--px-lg);
+  --board-body-padding-h: 0;
+  --board-heading-fsize: 16px;
+  --board-media-max-width: 100%;
+  --board-footer-col-indent: 12px;
+  --faq-list-a-padding-v: 16px;
+  --faq-list-a-padding-h: 0;
+  --faq-list-a-size: 16px;
+  --faq-list-q-padding: 16px 0;
+
+  @include tablet {
+    font-size: 16px;
+    --px-md: 16px;
+    --px-lg: 32px;
+    --px-xlg: 56px;
+    --input-md: 48px;
+    --input-md-fsize: 16px;
+    --textarea-md: 140px;
+    --space-xsm: 8px;
+    --space-xsm2: 12px;
+    --space-sm: 14px;
+    --space-sm2: 16px;
+    --space-md: 24px;
+    --space-md2: 24px;
+    --space-md3: 24px;
+    --space-box: 64px;
+    --space-box2: 120px;
+    --heading-2: 24px;
+    --heading-2-margin: 48px 0 24px;
+    --heading-4: 18px;
+    --heading-4-margin: 24px 0 8px;
+    --heading-info: 18px;
+    --heading-box: 20px;
+    --btn-md: 44px;
+    --btn-xlg: 52px;
+    --btn-xlg2: 48px;
+    --btn-xxlg: 80px;
+    --btn-xxlg-size: 16px;
+    --ic-sm: 24px;
+    --ic-md: 28px;
+    --ic-lg: 32px;
+    --ic-xlg: 48px;
+    --ic-xlg2: 48px;
+    --ic-xxlg: 80px;
+    --header-height: 56px;
+    --footer-height: 296px;
+    --side-padding: 48px;
+    --bottom-padding: 80px;
+    --h1-height: 160px;
+    --h1-fsize: 40px;
+    --h1-fsize-sm: 14px;
+    --tab-fsize: var(--font-size);
+    --search-bar-width: 400px;
+    --gallery-list-length: 2;
+    --gallery-list-space: var(--space-md);
+    --gallery-list-title-space: 12px;
+    --gallery-list-title-size: 16px;
+    --list-more-size: 16px;
+    --board-head-padding: 24px 24px;
+    --board-body-padding-v: var(--px-lg);
+    --board-body-padding-h: 24px;
+    --board-heading-fsize: 20px;
+    --board-media-max-width: 100%;
+    --board-footer-col-indent: 24px;
+    --faq-list-a-padding-v: 24px;
+    --faq-list-a-padding-h: 24px;
+    --faq-list-a-size: 20px;
+    --faq-list-q-padding: 24px 24px;
+  }
+
+  @include desktop-sm {
+    font-size: 18px;
+    --px-md: 20px;
+    --px-lg: 40px;
+    --px-xlg: 64px;
+    --input-md: 48px;
+    --input-md-fsize: 14px;
+    --textarea-md: 140px;
+    --space-xsm: 12px;
+    --space-xsm2: 16px;
+    --space-sm: 20px;
+    --space-sm2: 16px;
+    --space-md: 24px;
+    --space-md2: 24px;
+    --space-md3: 32px;
+    --space-box: 48px;
+    --space-box2: 160px;
+    --heading-2: 24px;
+    --heading-2-margin: 48px 0 24px;
+    --heading-4: 18px;
+    --heading-4-margin: 24px 0 8px;
+    --heading-info: 20px;
+    --heading-box: 20px;
+    --btn-md: 48px;
+    --btn-xlg: 56px;
+    --btn-xlg2: 56px;
+    --btn-xxlg: 80px;
+    --btn-xxlg-size: 18px;
+    --ic-sm: 24px;
+    --ic-md: 32px;
+    --ic-lg: 48px;
+    --ic-xlg: 48px;
+    --ic-xlg2: 56px;
+    --ic-xxlg: 80px;
+    --header-height: 80px;
+    --footer-height: 176px;
+    --side-padding: 48px;
+    --bottom-padding: 80px;
+    --h1-height: 192px;
+    --h1-fsize: 48px;
+    --h1-fsize-sm: 16px;
+    --tab-fsize: 20px;
+    --search-bar-width: 480px;
+    --gallery-list-length: 3;
+    --gallery-list-space: var(--space-md);
+    --gallery-list-title-space: 16px;
+    --gallery-list-title-size: 18px;
+    --list-more-size: 18px;
+    --board-head-padding: 28px 32px;
+    --board-body-padding-v: var(--px-lg);
+    --board-body-padding-h: 32px;
+    --board-heading-fsize: 24px;
+    --board-media-max-width: 100%;
+    --board-footer-col-indent: 32px;
+    --faq-list-a-padding-v: 18px;
+    --faq-list-a-padding-h: 20px;
+    --faq-list-a-size: 18px;
+    --faq-list-q-padding: 24px 32px;
+  }
+
+  @include desktop-lg {
+    font-size: 18px;
+    --px-md: 24px;
+    --px-lg: 48px;
+    --px-xlg: 76px;
+    --input-md: 56px;
+    --input-md-fsize: 18px;
+    --textarea-md: 200px;
+    --space-xsm: 16px;
+    --space-xsm2: 16px;
+    --space-sm: 20px;
+    --space-sm2: 20px;
+    --space-md: 32px;
+    --space-md2: 28px;
+    --space-md3: 32px;
+    --space-box: 64px;
+    --space-box2: 160px;
+    --heading-2: 24px;
+    --heading-2-margin: 64px 0 24px;
+    --heading-4: 20px;
+    --heading-4-margin: 28px 0 12px;
+    --heading-info: 24px;
+    --heading-box: 24px;
+    --btn-md: 48px;
+    --btn-xlg: 56px;
+    --btn-xlg2: 56px;
+    --btn-xxlg: 80px;
+    --btn-xxlg-size: 18px;
+    --ic-sm: 24px;
+    --ic-md: 32px;
+    --ic-lg: 48px;
+    --ic-xlg: 56px;
+    --ic-xlg2: 64px;
+    --ic-xxlg: 96px;
+    --header-height: 80px;
+    --footer-height: 176px;
+    --side-padding: 48px;
+    --bottom-padding: 96px;
+    --h1-height: 222px;
+    --h1-fsize: 56px;
+    --h1-fsize-sm: 18px;
+    --tab-fsize: 20px;
+    --search-bar-width: 480px;
+    --gallery-list-length: 3;
+    --gallery-list-space: var(--space-md);
+    --gallery-list-title-space: 20px;
+    --gallery-list-title-size: 20px;
+    --list-more-size: 18px;
+    --board-head-padding: 32px 40px;
+    --board-body-padding-v: var(--px-lg);
+    --board-body-padding-h: 40px;
+    --board-heading-fsize: 28px;
+    --board-media-max-width: 960px;
+    --board-footer-col-indent: 32px;
+    --faq-list-a-padding-v: 24px;
+    --faq-list-a-padding-h: 24px;
+    --faq-list-a-size: 20px;
+    --faq-list-q-padding: 32px 40px;
+  }
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
## 주요 변경사항

### 1. **SCSS 도입**
   - `sass` 패키지를 의존성으로 추가 (v1.86.0)
   - CSS 파일 확장자를 SCSS로 변경 (`.css` → `.scss`)

### 2. **전역 스타일 경로 변경**
   - 기존: `./globals.css` → 변경: `@/styles/global.scss`

### 3. **브레이크포인트 분리 및 적용**
   - 브레이크포인트를 별도 파일로 분리하여 재사용성 향상
   - 하드코딩된 미디어 쿼리 값(`@media (max-width: 768px)`) → SCSS 믹스인(`@include mobile-and-tablet`)으로 대체
   - `FAQAccordion.module.scss`에 브레이크포인트 파일 import 추가
   
### 4. CSS 변수 설정
 - 디자인 시스템을 위한 CSS 변수들 추가
 - 색상, 간격 등의 공통 스타일 값을 변수화 