### PR TITLE
feat: 캐시 전략 설정

### DIFF
--- a/lib/react-query/queryClientOptions.ts
+++ b/lib/react-query/queryClientOptions.ts
@@ -3,7 +3,8 @@ import { Query, defaultShouldDehydrateQuery } from '@tanstack/react-query';
 const queryClientOptions = {
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60,
+      staleTime: Infinity,
+      gcTime: Infinity,
     },
     throwOnError: true,
     dehydrate: {

--- a/services/faq.ts
+++ b/services/faq.ts
@@ -12,6 +12,9 @@ export async function fetchCategories(
 ): Promise<Category[]> {
   const response = await fetch(
     `${API_BASE_URL}/api/faq/category?tab=${category}`,
+    {
+      cache: 'no-store',
+    },
   );
 
   if (!response.ok) {
@@ -53,6 +56,9 @@ export async function fetchFaqs(
 
   const response = await fetch(
     `${API_BASE_URL}/api/faq?${queryParams.toString()}`,
+    {
+      cache: 'no-store',
+    },
   );
 
   if (!response.ok) {


### PR DESCRIPTION
## 변경사항

- 쿼리의 `staleTime`을 무한으로 설정하여 수동으로 무효화하기 전까지 새로운 API 요청을 하지 않도록 함
- `gcTime`을 무한으로 설정하여 컴포넌트가 언마운트되어도 가비지 컬렉션을 비활성화해 메모리에 유지하도록 함
- FAQ는 매우 정적인 데이터로 자주 변경되지 않으므로 브라우저 세션 동안 캐시를 활용하고, 브라우저를 닫거나 새로고침하면 캐시가 초기화되므로 API 재호출
- FAQ 카테고리 및 목록 `fetch` 요청 시 `no-store` 캐시 설정을 추가하여 Next.js의 자체 캐싱과 React Query의 캐싱이 충돌하는 것을 방지함
